### PR TITLE
Add age/sex formatted intro to history section

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,18 +54,24 @@
       </section>
       <section id="historySection" data-title="History">
         <h2>Routine History</h2>
-        <h3>Patient History & Present Illness Narrative</h3>
-        <textarea
-          id="patientHistoryNarrative"
-          rows="12"
-          placeholder="e.g., This is a 31-year-old woman with..."
-        ></textarea>
+        <label>Age:
+          <input type="text" id="hist_age" placeholder="e.g., 56" />
+        </label>
+        <label>Sex:
+          <input type="text" id="hist_sex" placeholder="e.g., woman" />
+        </label>
         <h3>Past Medical History (Structured)</h3>
         <textarea
           id="hist_pmh"
           rows="4"
           placeholder="1. Unclassified connective tissue disease...
 2. Suspected secondary Sjogren's syndrome"
+        ></textarea>
+        <h3>Present Illness Narrative</h3>
+        <textarea
+          id="patientHistoryNarrative"
+          rows="12"
+          placeholder="e.g., She has been in her usual health until..."
         ></textarea>
         <h3>Medication Allergy</h3>
         <div class="grid">

--- a/script.js
+++ b/script.js
@@ -178,6 +178,15 @@ document.addEventListener("DOMContentLoaded", () => {
       ? "■"
       : "□";
 
+  const ageSexSentence = () => {
+    const age = getVal("hist_age");
+    const sex = getVal("hist_sex");
+    if (age && sex) {
+      return `This is a ${age}-year-old ${sex} with the following history:`;
+    }
+    return "";
+  };
+
   const compileChecklistSection = (sectionId, title) => {
     const section = document.getElementById(sectionId);
     if (!section) return "";
@@ -243,13 +252,21 @@ Social History:
   };
 
   const assembleHistoryBlockForCopy = () => {
-    return `病史(Patient History)\n${getVal("patientHistoryNarrative", "Not specified")}\n\n[Past medical history]\n${getVal("hist_pmh", "Not specified")}\n\n${assembleSecondaryHistory()}`;
+    const intro = ageSexSentence();
+    const pmh = getVal("hist_pmh", "Not specified");
+    const pi = getVal("patientHistoryNarrative", "Not specified");
+    let lines = [];
+    if (intro) lines.push(intro);
+    if (pmh) lines.push(pmh);
+    if (pi) lines.push(pi);
+    return `${lines.join("\n")}\n\n${assembleSecondaryHistory()}`;
   };
 
   const assembleFullNoteText = () => {
     const chiefComplaint = `主訴(Chief Complaint)\nInformant: ${getVal("informant")}\n${getVal("ccpi")}`;
     const pastMedicalHistory = `[Past medical history]\n${getVal("hist_pmh", "Not specified")}`;
-    const patientHistoryNarrative = `病史(Patient History)\n${getVal("patientHistoryNarrative", "Not specified")}`;
+    const presentIllness = getVal("patientHistoryNarrative", "Not specified");
+    const patientHistoryNarrative = `病史(Patient History)\n${ageSexSentence()}\n${pastMedicalHistory}\n${presentIllness}`;
     const secondaryHistory = assembleSecondaryHistory();
     const vitalsText = `BH: ${getVal("vitals_bh", "--")} cm, BW: ${getVal("vitals_bw", "--")} kg, T: ${getVal("vitals_t", "--")} C, P: ${getVal("vitals_p", "--")} bpm, R: ${getVal("vitals_r", "--")} /min, BP: ${getVal("vitals_bp", "--/--")} mmHg, Pain score: ${getVal("vitals_pain", "--")}`;
 
@@ -300,7 +317,6 @@ Treatment goal: ${getVal("plan_treatment_goal")}`;
 
     return [
       chiefComplaint,
-      pastMedicalHistory,
       patientHistoryNarrative,
       secondaryHistory,
       `Psychosocial Assessment\n${getVal("psychosocial_assessment")}`,


### PR DESCRIPTION
## Summary
- collect patient age and sex in the Routine History section
- show Past Medical History before the Present Illness field
- output formatted intro sentence with age and sex in history block and full note

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686720ec9a9883248179bca698e84bd1